### PR TITLE
Implement typed MMU hygiene checks and add regression tests

### DIFF
--- a/mmu.py
+++ b/mmu.py
@@ -1,18 +1,18 @@
 import logging
-from dataclasses import dataclass, field
-from typing import List, Tuple, Dict, Optional
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+
 
 # Simple s-expression parser for MMU files
 
-def _tokenize(text: str):
+
+def _tokenize(text: str) -> List[str]:
     tokens: List[str] = []
     i = 0
     n = len(text)
     while i < n:
         c = text[i]
-        # Line comments start with '--' and run to end of line
         if c == '-' and i + 1 < n and text[i + 1] == '-':
-            # Skip the rest of the line
             while i < n and text[i] != '\n':
                 i += 1
             continue
@@ -25,7 +25,7 @@ def _tokenize(text: str):
             continue
         if c == '"':
             j = i + 1
-            buf = []
+            buf: List[str] = []
             while j < n:
                 if text[j] == '"' and text[j - 1] != '\\':
                     break
@@ -61,128 +61,308 @@ def parse_sexpr(text: str):
         raise ValueError('unmatched (')
     return stack[0]
 
+
+@dataclass(frozen=True)
+class SortInfo:
+    name: str
+    strict: bool
+    provable: bool
+
+
+@dataclass(frozen=True)
+class TypeAnnot:
+    sort: str
+    deps: Tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class TermSig:
+    name: str
+    args: Tuple[TypeAnnot, ...]
+    ret: TypeAnnot
+
+
 @dataclass(frozen=True)
 class Expr:
-    kind: str  # 'var' or 'term'
-    name: str
+    kind: str  # 'var' | 'dummy' | 'app'
+    sym: Optional[str]
     args: Tuple['Expr', ...]
     sort: str
+    free_dummies: frozenset[int]
+
+
+@dataclass(frozen=True)
+class VarInfo:
+    sort: str
+    kind: str  # 'param' | 'dummy'
+    dummy_id: Optional[int]
+
+
+@dataclass(frozen=True)
+class BinderDecl:
+    name: str
+    annot: TypeAnnot
+    kind: str  # 'param' | 'dummy'
+    index: int
+    dummy_id: Optional[int]
+
 
 @dataclass
-class Term:
+class TermDecl:
     name: str
-    args: List[Tuple[str, str]]  # (var, sort)
-    ret: str
+    sig: TermSig
+    args: Tuple[BinderDecl, ...]
+    dummies: Tuple[BinderDecl, ...]
     def_body: Optional[Expr] = None
-    dummy: List[Tuple[str, str]] = field(default_factory=list)
+
 
 @dataclass
-class Thm:
+class TheoremDecl:
     name: str
-    params: List[Tuple[str, str]]  # (var, sort)
-    hyps: List[Expr]
+    params: Tuple[BinderDecl, ...]
+    hyps: Tuple[Expr, ...]
     concl: Expr
 
+
 class MMUVerifier:
-    def __init__(self, logger: logging.Logger | None = None):
-        self.sorts: Dict[str, None] = {}
-        self.terms: Dict[str, Term] = {}
-        self.theorems: Dict[str, Thm] = {}
+    def __init__(self, logger: Optional[logging.Logger] = None):
+        self.sorts: Dict[str, SortInfo] = {}
+        self.terms: Dict[str, TermDecl] = {}
+        self.theorems: Dict[str, TheoremDecl] = {}
+        self._next_dummy_id = 0
         self.logger = logger or logging.getLogger(__name__)
 
-    # Parsing helpers
-    def _parse_params(self, params_ast):
-        params = []
-        env = {}
-        for item in params_ast:
-            var, sort = item[0], item[1]
-            if sort not in self.sorts:
-                raise ValueError(f'unknown sort {sort}')
-            params.append((var, sort))
-            env[var] = sort
-        return params, env
+    # ------------------------------------------------------------------
+    # Binder helpers
 
-    def _read_expr(self, ast, env):
+    def _fresh_dummy_id(self) -> int:
+        dummy = self._next_dummy_id
+        self._next_dummy_id += 1
+        return dummy
+
+    def _lookup_sort(self, sort: str) -> SortInfo:
+        if sort not in self.sorts:
+            raise ValueError(f'unknown sort {sort}')
+        return self.sorts[sort]
+
+    def _make_type_annotation(
+        self,
+        sort: str,
+        deps_ast: Sequence,
+        binders: Sequence[BinderDecl],
+        binder_env: Mapping[str, BinderDecl],
+    ) -> TypeAnnot:
+        self._lookup_sort(sort)
+        if not deps_ast:
+            return TypeAnnot(sort, ())
+        dep_indices: List[int] = []
+        for dep in deps_ast:
+            if dep not in binder_env:
+                raise ValueError(f'unknown dependency {dep}')
+            binder = binder_env[dep]
+            dep_indices.append(binder.index)
+        return TypeAnnot(sort, tuple(dep_indices))
+
+    def _parse_single_binder(
+        self,
+        entry: Sequence,
+        binders: List[BinderDecl],
+        binder_env: MutableMapping[str, BinderDecl],
+        *,
+        allow_param: bool = True,
+        allow_dummy: bool = True,
+        len2_kind: str = 'dummy',
+    ) -> BinderDecl:
+        if not entry:
+            raise ValueError('invalid binder entry')
+        if len(entry) == 2:
+            if not allow_dummy:
+                raise ValueError('unexpected dummy binder')
+            name, sort = entry
+            if name in binder_env:
+                if name.startswith('_'):
+                    name = f'{name}{len(binders)}'
+                else:
+                    raise ValueError(f'duplicate variable {name}')
+            if len2_kind == 'dummy':
+                binder = BinderDecl(
+                    name=name,
+                    annot=TypeAnnot(sort, ()),
+                    kind='dummy',
+                    index=len(binders),
+                    dummy_id=self._fresh_dummy_id(),
+                )
+            else:
+                binder = BinderDecl(
+                    name=name,
+                    annot=TypeAnnot(sort, ()),
+                    kind='param',
+                    index=len(binders),
+                    dummy_id=None,
+                )
+        elif len(entry) == 3:
+            if not allow_param:
+                raise ValueError('unexpected parameter binder')
+            name, sort, deps_ast = entry
+            if name in binder_env:
+                if name.startswith('_'):
+                    name = f'{name}{len(binders)}'
+                else:
+                    raise ValueError(f'duplicate variable {name}')
+            annot = self._make_type_annotation(sort, deps_ast, binders, binder_env)
+            binder = BinderDecl(
+                name=name,
+                annot=annot,
+                kind='param',
+                index=len(binders),
+                dummy_id=None,
+            )
+        else:
+            raise ValueError('invalid binder entry')
+        return binder
+
+    def _parse_binders(
+        self,
+        binder_asts: Sequence[Sequence],
+        binders: List[BinderDecl],
+        binder_env: MutableMapping[str, BinderDecl],
+        *,
+        allow_param: bool = True,
+        allow_dummy: bool = True,
+        len2_kind: str = 'dummy',
+    ) -> Tuple[BinderDecl, ...]:
+        result: List[BinderDecl] = []
+        for entry in binder_asts:
+            binder = self._parse_single_binder(
+                entry,
+                binders,
+                binder_env,
+                allow_param=allow_param,
+                allow_dummy=allow_dummy,
+                len2_kind=len2_kind,
+            )
+            binders.append(binder)
+            binder_env[binder.name] = binder
+            result.append(binder)
+        return tuple(result)
+
+    def _varinfo_from_binder(self, binder: BinderDecl) -> VarInfo:
+        if binder.kind == 'dummy':
+            return VarInfo(binder.annot.sort, 'dummy', binder.dummy_id)
+        return VarInfo(binder.annot.sort, 'param', None)
+
+    # ------------------------------------------------------------------
+    # Expression helpers
+
+    def _allowed_from_deps(
+        self,
+        deps: Tuple[int, ...],
+        binders: Sequence[BinderDecl],
+        dummy_sets: Mapping[int, frozenset[int]],
+    ) -> frozenset[int]:
+        if not deps:
+            return frozenset()
+        allowed: set[int] = set()
+        for idx in deps:
+            if idx < 0 or idx >= len(binders):
+                raise ValueError('dependency index out of range')
+            binder = binders[idx]
+            if idx not in dummy_sets:
+                raise ValueError('dependency binder has no instantiation')
+            allowed |= dummy_sets[idx]
+        return frozenset(allowed)
+
+    def _initial_dummy_sets(self, binders: Sequence[BinderDecl]) -> Dict[int, frozenset[int]]:
+        dummy_sets: Dict[int, frozenset[int]] = {}
+        for binder in binders:
+            if binder.kind == 'dummy':
+                if binder.dummy_id is None:
+                    raise ValueError('missing dummy id')
+                dummy_sets[binder.index] = frozenset({binder.dummy_id})
+            else:
+                dummy_sets[binder.index] = frozenset()
+        return dummy_sets
+
+    def _read_expr(self, ast, env: Mapping[str, VarInfo]) -> Expr:
         if isinstance(ast, str):
             if ast in env:
-                return Expr('var', ast, (), env[ast])
-            if ast in self.terms and not self.terms[ast].args:
-                t = self.terms[ast]
-                return Expr('term', ast, (), t.ret)
+                info = env[ast]
+                if info.kind == 'dummy':
+                    if info.dummy_id is None:
+                        raise ValueError('internal error: missing dummy id')
+                    return Expr('dummy', ast, (), info.sort, frozenset({info.dummy_id}))
+                return Expr('var', ast, (), info.sort, frozenset())
+            if ast in self.terms:
+                term = self.terms[ast]
+                if term.sig.args:
+                    raise ValueError(f'arity mismatch for {ast}')
+                expr, _ = self._analyze_app(ast, [])
+                return expr
             raise ValueError(f'unknown symbol {ast}')
+        if not ast:
+            raise ValueError('empty expression')
         name = ast[0]
+        arg_exprs = [self._read_expr(sub_ast, env) for sub_ast in ast[1:]]
+        expr, _ = self._analyze_app(name, arg_exprs)
+        return expr
+
+    def _analyze_app(
+        self, name: str, args: Sequence[Expr]
+    ) -> Tuple[Expr, Dict[int, frozenset[int]]]:
         if name not in self.terms:
             raise ValueError(f'unknown term {name}')
-        t = self.terms[name]
-        if len(ast) - 1 != len(t.args):
+        term = self.terms[name]
+        if len(args) != len(term.args):
             raise ValueError(f'arity mismatch for {name}')
-        args = []
-        for sub_ast, (_, sort) in zip(ast[1:], t.args):
-            e = self._read_expr(sub_ast, env)
-            if e.sort != sort:
+        dummy_sets: Dict[int, frozenset[int]] = {}
+        result_free: set[int] = set()
+        for binder, arg_expr in zip(term.args, args):
+            if arg_expr.sort != binder.annot.sort:
                 raise ValueError(f'sort mismatch in {name}')
-            args.append(e)
-        return Expr('term', name, tuple(args), t.ret)
+            allowed = self._allowed_from_deps(binder.annot.deps, term.args, dummy_sets)
+            sort_info = self._lookup_sort(arg_expr.sort)
+            if sort_info.strict and binder.kind == 'dummy':
+                if not arg_expr.free_dummies.issubset(allowed):
+                    raise ValueError('strict dependency violation in argument')
+            dummy_sets[binder.index] = arg_expr.free_dummies
+            if binder.kind != 'dummy':
+                result_free |= arg_expr.free_dummies
+        for binder in term.args:
+            if binder.kind == 'dummy':
+                result_free -= dummy_sets.get(binder.index, frozenset())
+        sort_info = self._lookup_sort(term.sig.ret.sort)
+        allowed_ret = set(self._allowed_from_deps(term.sig.ret.deps, term.args, dummy_sets))
+        for binder in term.args:
+            if binder.kind != 'dummy':
+                allowed_ret |= set(dummy_sets.get(binder.index, frozenset()))
+        if sort_info.strict and not result_free.issubset(allowed_ret):
+            raise ValueError('strict dependency violation in result')
+        expr = Expr('app', name, tuple(args), term.sig.ret.sort, frozenset(result_free))
+        return expr, dummy_sets
 
-    def _instantiate(self, expr: Expr, subst: Dict[str, Expr]):
-        if expr.kind == 'var':
-            return subst.get(expr.name, expr)
-        return Expr('term', expr.name,
-                    tuple(self._instantiate(a, subst) for a in expr.args),
-                    expr.sort)
+    def _instantiate(self, expr: Expr, subst: Mapping[str, Expr]) -> Expr:
+        if expr.kind in {'var', 'dummy'}:
+            if expr.sym in subst:
+                return subst[expr.sym]
+            return expr
+        if expr.kind != 'app':
+            raise ValueError('unknown expression kind')
+        args = [self._instantiate(a, subst) for a in expr.args]
+        return self._build_app(expr.sym, args)
 
-    def _eval_proof(self, ast, env, hyps):
-        if isinstance(ast, str):
-            if ast not in hyps:
-                raise ValueError(f'unknown hypothesis {ast}')
-            return hyps[ast]
-        name = ast[0]
-        if name == ':let':
-            label = ast[1]
-            bound_ast = ast[2]
-            bound_val = self._eval_proof(bound_ast, env, hyps)
-            hyps[label] = bound_val
-            if len(ast) == 4:
-                body_ast = ast[3]
-                return self._eval_proof(body_ast, env, hyps)
-            return bound_val
-        if name == ':conv':
-            goal_ast, conv_ast, proof_ast = ast[1], ast[2], ast[3]
-            goal = self._read_expr(goal_ast, env)
-            lhs, rhs = self._eval_conv(conv_ast, env, hyps)
-            if lhs != goal:
-                raise ValueError('conversion goal mismatch')
-            proof_res = self._eval_proof(proof_ast, env, hyps)
-            if proof_res != rhs:
-                raise ValueError('conversion proof mismatch')
-            return goal
-        if name not in self.theorems:
-            raise ValueError(f'unknown theorem {name}')
-        th = self.theorems[name]
-        param_asts = ast[1]
-        if len(param_asts) != len(th.params):
-            raise ValueError('parameter count mismatch')
-        subst = {}
-        for (pname, psort), arg_ast in zip(th.params, param_asts):
-            arg = self._read_expr(arg_ast, env)
-            if arg.sort != psort:
-                raise ValueError('parameter sort mismatch')
-            subst[pname] = arg
-        proof_asts = ast[2:]
-        if len(proof_asts) != len(th.hyps):
-            raise ValueError('hypothesis count mismatch')
-        for p_ast, hyp in zip(proof_asts, th.hyps):
-            want = self._instantiate(hyp, subst)
-            got = self._eval_proof(p_ast, env, hyps)
-            if got != want:
-                raise ValueError(
-                    f'hypothesis mismatch: expected {want}, got {got}')
-        return self._instantiate(th.concl, subst)
+    def _build_app(self, name: str, args: Sequence[Expr]) -> Expr:
+        expr, _ = self._analyze_app(name, args)
+        return expr
 
-    def _eval_conv(self, ast, env, hyps):
+    # ------------------------------------------------------------------
+    # Proof helpers
+
+    def _eval_conv(self, ast, env: Mapping[str, VarInfo], hyps: Mapping[str, Expr]) -> Tuple[Expr, Expr]:
         if isinstance(ast, str):
             e = self._read_expr(ast, env)
             return e, e
+        if not ast:
+            raise ValueError('empty conversion expression')
         name = ast[0]
         if name == ':refl':
             if len(ast) != 2:
@@ -210,88 +390,181 @@ class MMUVerifier:
             term = self.terms[term_name]
             if term.def_body is None:
                 raise ValueError('cannot unfold non-definition')
-            args = [self._read_expr(a, env) for a in args_ast]
-            if len(args) != len(term.args):
-                raise ValueError('arity mismatch in unfold')
-            if len(dummy_ast) != len(term.dummy):
+            args = [self._read_expr(arg, env) for arg in args_ast]
+            lhs, dummy_sets = self._analyze_app(term_name, args)
+            binders = list(term.args)
+            binder_env = {binder.name: binder for binder in binders}
+            dummy_exprs: List[Expr] = []
+            if len(dummy_ast) != len(term.dummies):
                 raise ValueError('dummy count mismatch in unfold')
-            lhs = Expr('term', term_name, tuple(args), term.ret)
-            subst = {var: arg for (var, _), arg in zip(term.args, args)}
-            for (dvar, dsort), d_ast in zip(term.dummy, dummy_ast):
-                d_val = self._read_expr(d_ast, env)
-                if d_val.sort != dsort:
+            for binder, ast_expr in zip(term.dummies, dummy_ast):
+                binders.append(binder)
+                binder_env[binder.name] = binder
+                expr = self._read_expr(ast_expr, env)
+                if expr.sort != binder.annot.sort:
                     raise ValueError('dummy sort mismatch in unfold')
-                subst[dvar] = d_val
+                allowed = self._allowed_from_deps(
+                    binder.annot.deps, binders, dummy_sets
+                )
+                sort_info = self._lookup_sort(expr.sort)
+                if sort_info.strict and not expr.free_dummies.issubset(allowed):
+                    raise ValueError('dummy dependency violation in unfold')
+                dummy_sets[binder.index] = expr.free_dummies
+                dummy_exprs.append(expr)
+            subst: Dict[str, Expr] = {}
+            for binder, arg_expr in zip(term.args, args):
+                subst[binder.name] = arg_expr
+            for binder, expr in zip(term.dummies, dummy_exprs):
+                subst[binder.name] = expr
             body = self._instantiate(term.def_body, subst)
-            lhs2, rhs2 = self._eval_conv(conv_ast, env, hyps)
-            if lhs2 != body:
+            lhs_conv, rhs_conv = self._eval_conv(conv_ast, env, hyps)
+            if lhs_conv != body:
                 raise ValueError('unfold body mismatch')
-            return lhs, rhs2
-        # general term application
-        args = [self._eval_conv(a, env, hyps) for a in ast[1:]]
-        lhs_args = [a[0] for a in args]
-        rhs_args = [a[1] for a in args]
-        if name not in self.terms:
-            raise ValueError(f'unknown term {name}')
-        t = self.terms[name]
-        if len(lhs_args) != len(t.args):
-            raise ValueError('arity mismatch in conv')
-        return (Expr('term', name, tuple(lhs_args), t.ret),
-                Expr('term', name, tuple(rhs_args), t.ret))
+            return lhs, rhs_conv
+        arg_pairs = [self._eval_conv(a, env, hyps) for a in ast[1:]]
+        lhs_args = [p[0] for p in arg_pairs]
+        rhs_args = [p[1] for p in arg_pairs]
+        lhs, _ = self._analyze_app(name, lhs_args)
+        rhs, _ = self._analyze_app(name, rhs_args)
+        return lhs, rhs
 
-    def _handle_sort(self, stmt):
+    def _eval_proof(
+        self,
+        ast,
+        env: MutableMapping[str, VarInfo],
+        hyps: MutableMapping[str, Expr],
+    ) -> Expr:
+        if isinstance(ast, str):
+            if ast not in hyps:
+                raise ValueError(f'unknown hypothesis {ast}')
+            return hyps[ast]
+        if not ast:
+            raise ValueError('empty proof expression')
+        name = ast[0]
+        if name == ':let':
+            label = ast[1]
+            bound_val = self._eval_proof(ast[2], env, hyps)
+            if label in hyps:
+                raise ValueError(f'shadowed hypothesis {label}')
+            hyps[label] = bound_val
+            if len(ast) == 4:
+                return self._eval_proof(ast[3], env, hyps)
+            return bound_val
+        if name == ':conv':
+            goal_ast, conv_ast, proof_ast = ast[1], ast[2], ast[3]
+            goal = self._read_expr(goal_ast, env)
+            lhs, rhs = self._eval_conv(conv_ast, env, hyps)
+            if lhs != goal:
+                raise ValueError('conversion goal mismatch')
+            proof_res = self._eval_proof(proof_ast, env, hyps)
+            if proof_res != rhs:
+                raise ValueError('conversion proof mismatch')
+            return goal
+        if name not in self.theorems:
+            raise ValueError(f'unknown theorem {name}')
+        th = self.theorems[name]
+        param_asts = ast[1]
+        if len(param_asts) != len(th.params):
+            raise ValueError('parameter count mismatch')
+        subst: Dict[str, Expr] = {}
+        dummy_sets: Dict[int, frozenset[int]] = {}
+        for binder, arg_ast in zip(th.params, param_asts):
+            arg_expr = self._read_expr(arg_ast, env)
+            if arg_expr.sort != binder.annot.sort:
+                raise ValueError('parameter sort mismatch')
+            allowed = self._allowed_from_deps(
+                binder.annot.deps, th.params, dummy_sets
+            )
+            sort_info = self._lookup_sort(arg_expr.sort)
+            if sort_info.strict and binder.kind == 'dummy':
+                if not arg_expr.free_dummies.issubset(allowed):
+                    raise ValueError('strict dependency violation in parameter')
+            dummy_sets[binder.index] = arg_expr.free_dummies
+            subst[binder.name] = arg_expr
+        proof_asts = ast[2:]
+        if len(proof_asts) != len(th.hyps):
+            raise ValueError('hypothesis count mismatch')
+        for p_ast, hyp in zip(proof_asts, th.hyps):
+            want = self._instantiate(hyp, subst)
+            got = self._eval_proof(p_ast, env, hyps)
+            if got != want:
+                raise ValueError('hypothesis mismatch')
+        return self._instantiate(th.concl, subst)
+
+    # ------------------------------------------------------------------
+    # Statement handlers
+
+    def _handle_sort(self, stmt: Sequence) -> None:
         name = stmt[1]
-        self.sorts[name] = None
+        flags = set(stmt[2:])
+        strict = 'strict' in flags
+        provable = 'provable' in flags
+        self.sorts[name] = SortInfo(name, strict, provable)
 
-    def _handle_term(self, stmt):
+    def _handle_term(self, stmt: Sequence) -> None:
         name = stmt[1]
         args_ast = stmt[2]
         ret_ast = stmt[3]
-        args = []
-        for v in args_ast:
-            if v[1] not in self.sorts:
-                raise ValueError(f'unknown sort {v[1]}')
-            args.append((v[0], v[1]))
+        binders: List[BinderDecl] = []
+        binder_env: Dict[str, BinderDecl] = {}
+        args = self._parse_binders(args_ast, binders, binder_env)
         ret_sort = ret_ast[0]
-        if ret_sort not in self.sorts:
-            raise ValueError(f'unknown sort {ret_sort}')
-        self.terms[name] = Term(name, args, ret_sort)
+        ret_deps_ast = ret_ast[1] if len(ret_ast) > 1 else []
+        ret_annot = self._make_type_annotation(ret_sort, ret_deps_ast, binders, binder_env)
+        sig = TermSig(name, tuple(b.annot for b in args), ret_annot)
+        self.terms[name] = TermDecl(name, sig, tuple(args), (), None)
 
-    def _handle_def(self, stmt):
+    def _handle_def(self, stmt: Sequence) -> None:
         name = stmt[1]
         args_ast = stmt[2]
         ret_ast = stmt[3]
         dummy_ast = stmt[4]
         expr_ast = stmt[5]
-        args = []
-        for v in args_ast:
-            if v[1] not in self.sorts:
-                raise ValueError(f'unknown sort {v[1]}')
-            args.append((v[0], v[1]))
+        binders: List[BinderDecl] = []
+        binder_env: Dict[str, BinderDecl] = {}
+        args = self._parse_binders(args_ast, binders, binder_env)
         ret_sort = ret_ast[0]
-        if ret_sort not in self.sorts:
-            raise ValueError(f'unknown sort {ret_sort}')
-        dummy_params, dummy_env = self._parse_params(dummy_ast)
-        term = Term(name, args, ret_sort, dummy=dummy_params)
-        self.terms[name] = term
-        _, env = self._parse_params(args_ast)
-        env.update(dummy_env)
-        expr = self._read_expr(expr_ast, env)
-        if expr.sort != term.ret:
+        ret_deps_ast = ret_ast[1] if len(ret_ast) > 1 else []
+        ret_annot = self._make_type_annotation(ret_sort, ret_deps_ast, binders, binder_env)
+        dummy_binders = self._parse_binders(dummy_ast, binders, binder_env, allow_param=False)
+        all_binders = tuple(binders)
+        expr_env = {binder.name: self._varinfo_from_binder(binder) for binder in all_binders}
+        expr = self._read_expr(expr_ast, expr_env)
+        if expr.sort != ret_sort:
             raise ValueError('definition sort mismatch')
-        term.def_body = expr
+        sort_info = self._lookup_sort(ret_sort)
+        if sort_info.strict:
+            dummy_sets = self._initial_dummy_sets(all_binders)
+            allowed = self._allowed_from_deps(ret_annot.deps, args, dummy_sets)
+            if not expr.free_dummies.issubset(allowed):
+                raise ValueError('definition dummy escape')
+        sig = TermSig(name, tuple(b.annot for b in args), ret_annot)
+        self.terms[name] = TermDecl(name, sig, tuple(args), tuple(dummy_binders), expr)
 
-    def _handle_axiom(self, stmt):
+    def _handle_axiom(self, stmt: Sequence) -> None:
         name = stmt[1]
         params_ast = stmt[2]
         hyps_ast = stmt[3]
         concl_ast = stmt[4]
-        params, env = self._parse_params(params_ast)
-        hyps = [self._read_expr(h, env) for h in hyps_ast]
-        concl = self._read_expr(concl_ast, env)
-        self.theorems[name] = Thm(name, params, hyps, concl)
+        binders: List[BinderDecl] = []
+        binder_env: Dict[str, BinderDecl] = {}
+        params = self._parse_binders(params_ast, binders, binder_env)
+        expr_env = {binder.name: self._varinfo_from_binder(binder) for binder in params}
+        hyps: List[Expr] = []
+        for hyp_ast in hyps_ast:
+            expr = self._read_expr(hyp_ast, expr_env)
+            sort_info = self._lookup_sort(expr.sort)
+            if not sort_info.provable:
+                raise ValueError('hypothesis in non-provable sort')
+            hyps.append(expr)
+        concl = self._read_expr(concl_ast, expr_env)
+        concl_info = self._lookup_sort(concl.sort)
+        if not concl_info.provable:
+            raise ValueError('conclusion in non-provable sort')
+        # Conclusions may contain free variables of non-strict sorts.
+        self.theorems[name] = TheoremDecl(name, tuple(params), tuple(hyps), concl)
 
-    def _handle_local(self, stmt):
+    def _handle_local(self, stmt: Sequence) -> None:
         kind = stmt[1]
         if kind == 'theorem':
             name = stmt[2]
@@ -300,85 +573,100 @@ class MMUVerifier:
             concl_ast = stmt[5]
             dummy_ast = stmt[6]
             proof_ast = stmt[7]
-            params, env = self._parse_params(params_ast)
-            dummy_params, dummy_env = self._parse_params(dummy_ast)
-            env.update(dummy_env)
-            hyps = []
-            hyp_env = {}
-            for h in hyps_ast:
-                label, expr_ast = h[0], h[1]
-                e = self._read_expr(expr_ast, env)
-                hyps.append(e)
-                hyp_env[label] = e
-            concl = self._read_expr(concl_ast, env)
-            res = self._eval_proof(proof_ast, env, hyp_env)
-            if res != concl:
+            binders: List[BinderDecl] = []
+            binder_env: Dict[str, BinderDecl] = {}
+            params = self._parse_binders(params_ast, binders, binder_env)
+            self._parse_binders(dummy_ast, binders, binder_env, allow_param=False)
+            expr_env = {
+                binder.name: self._varinfo_from_binder(binder)
+                for binder in binders
+            }
+            hyps: List[Expr] = []
+            hyp_env: Dict[str, Expr] = {}
+            for hyp_entry in hyps_ast:
+                if isinstance(hyp_entry, list) and len(hyp_entry) == 2:
+                    label, expr_ast = hyp_entry
+                else:
+                    label, expr_ast = None, hyp_entry
+                expr = self._read_expr(expr_ast, expr_env)
+                hyp_info = self._lookup_sort(expr.sort)
+                if not hyp_info.provable:
+                    raise ValueError('hypothesis in non-provable sort')
+                hyps.append(expr)
+                if label:
+                    if label in hyp_env:
+                        raise ValueError(f'duplicate hypothesis label {label}')
+                    hyp_env[label] = expr
+            concl = self._read_expr(concl_ast, expr_env)
+            concl_info = self._lookup_sort(concl.sort)
+            if not concl_info.provable:
+                raise ValueError('conclusion in non-provable sort')
+            proof = self._eval_proof(proof_ast, dict(expr_env), dict(hyp_env))
+            if proof != concl:
                 raise ValueError(
                     f'proof of {name} does not match conclusion\n'
-                    f'  expected {concl}\n  got {res}')
-            self.theorems[name] = Thm(name, params, hyps, concl)
+                    f'  expected {concl}\n  got {proof}'
+                )
+            self.theorems[name] = TheoremDecl(name, tuple(params), tuple(hyps), concl)
         elif kind == 'def':
             name = stmt[2]
             params_ast = stmt[3]
             ret_ast = stmt[4]
             dummy_ast = stmt[5]
             expr_ast = stmt[6]
-            args = []
-            for v in params_ast:
-                if v[1] not in self.sorts:
-                    raise ValueError(f'unknown sort {v[1]}')
-                args.append((v[0], v[1]))
-            ret_sort = ret_ast[0]
-            if ret_sort not in self.sorts:
-                raise ValueError(f'unknown sort {ret_sort}')
-            dummy_params, dummy_env = self._parse_params(dummy_ast)
-            term = Term(name, args, ret_sort, dummy=dummy_params)
-            self.terms[name] = term
-            _, env = self._parse_params(params_ast)
-            env.update(dummy_env)
-            expr = self._read_expr(expr_ast, env)
-            if expr.sort != term.ret:
-                raise ValueError('definition sort mismatch')
-            term.def_body = expr
+            self._handle_def(['def', name, params_ast, ret_ast, dummy_ast, expr_ast])
         else:
             self.logger.warning('unknown local statement')
 
-    def _handle_theorem(self, stmt):
+    def _handle_theorem(self, stmt: Sequence) -> None:
         name = stmt[1]
         params_ast = stmt[2]
         hyps_ast = stmt[3]
         concl_ast = stmt[4]
         dummy_ast = stmt[5]
         proof_ast = stmt[6]
-        params, env = self._parse_params(params_ast)
-        _, dummy_env = self._parse_params(dummy_ast)
-        env.update(dummy_env)
-        hyps = []
+        binders: List[BinderDecl] = []
+        binder_env: Dict[str, BinderDecl] = {}
+        params = self._parse_binders(params_ast, binders, binder_env)
+        self._parse_binders(dummy_ast, binders, binder_env, allow_param=False)
+        expr_env = {binder.name: self._varinfo_from_binder(binder) for binder in binders}
+        hyps: List[Expr] = []
         hyp_env: Dict[str, Expr] = {}
-        for h_ast in hyps_ast:
-            if isinstance(h_ast, list) and len(h_ast) == 2:
-                label, expr_ast = h_ast
+        for entry in hyps_ast:
+            if isinstance(entry, list) and len(entry) == 2:
+                label, expr_ast = entry
             else:
-                label, expr_ast = None, h_ast
-            h_expr = self._read_expr(expr_ast, env)
-            hyps.append(h_expr)
+                label, expr_ast = None, entry
+            expr = self._read_expr(expr_ast, expr_env)
+            hyp_info = self._lookup_sort(expr.sort)
+            if not hyp_info.provable:
+                raise ValueError('hypothesis in non-provable sort')
+            hyps.append(expr)
             if label:
-                hyp_env[label] = h_expr
-        concl = self._read_expr(concl_ast, env)
-        res = self._eval_proof(proof_ast, env, hyp_env)
-        if res != concl:
+                if label in hyp_env:
+                    raise ValueError(f'duplicate hypothesis label {label}')
+                hyp_env[label] = expr
+        concl = self._read_expr(concl_ast, expr_env)
+        concl_info = self._lookup_sort(concl.sort)
+        if not concl_info.provable:
+            raise ValueError('conclusion in non-provable sort')
+        result = self._eval_proof(proof_ast, dict(expr_env), dict(hyp_env))
+        if result != concl:
             raise ValueError(
                 f'proof of {name} does not match conclusion\n'
-                f'  expected {concl}\n  got {res}')
-        self.theorems[name] = Thm(name, params, hyps, concl)
+                f'  expected {concl}\n  got {result}'
+            )
+        self.theorems[name] = TheoremDecl(name, tuple(params), tuple(hyps), concl)
 
-    def _handle_output(self, stmt):
-        pass
+    def _handle_output(self, stmt: Sequence) -> None:  # noqa: D401
+        """Outputs are ignored by the verifier."""
 
-    def process(self, stmts):
+    def process(self, stmts: Sequence[Sequence]) -> None:
         for i, stmt in enumerate(stmts, 1):
+            if not stmt:
+                continue
             head = stmt[0]
-            self.logger.debug(f'processing {i}: {head}')
+            self.logger.debug('processing %d: %s', i, head)
             if head == '-':
                 continue
             if head == 'pub':
@@ -388,29 +676,23 @@ class MMUVerifier:
                     stmt = stmt[1:]
                 head = stmt[0]
             handler = getattr(self, f'_handle_{head}', None)
-            if handler:
-                handler(stmt)
-            else:
-                self.logger.warning(f'unknown statement {head}')
+            if handler is None:
+                self.logger.warning('unknown statement %s', head)
+                continue
+            handler(stmt)
 
 
-def verify_mmu(path: str, logger: logging.Logger | None = None):
+def verify_mmu(path: str, logger: Optional[logging.Logger] = None) -> MMUVerifier:
     with open(path, 'r') as f:
         text = f.read()
     stmts = parse_sexpr(text)
-    v = MMUVerifier(logger=logger)
-    v.process(stmts)
-    return v
+    verifier = MMUVerifier(logger=logger)
+    verifier.process(stmts)
+    return verifier
 
 
-def verify_mmb(_mm0_path: str, mmb_path: str):
-    """Perform basic structural checks on an `.mmb` file.
-
-    This lightweight parser reads the header and table pointers of the
-    binary proof file and ensures that all referenced regions are within
-    the file bounds. It does **not** invoke `mm0-c` or attempt full proof
-    checking; test suites compare its behavior against the reference
-    verifier separately."""
+def verify_mmb(_mm0_path: str, mmb_path: str) -> None:
+    """Perform basic structural checks on an `.mmb` file."""
     import struct
 
     with open(mmb_path, 'rb') as f:
@@ -420,8 +702,7 @@ def verify_mmb(_mm0_path: str, mmb_path: str):
         raise ValueError('file too small to be an MMB file')
 
     header = struct.unpack_from('<4sBBHIIIIIIQ', data, 0)
-    magic, version, num_sorts, _res, num_terms, num_thms, p_terms, p_thms, \
-        p_proof, _res2, p_index = header
+    magic, version, num_sorts, _res, num_terms, num_thms, p_terms, p_thms, p_proof, _res2, p_index = header
 
     if magic != b'MM0B':
         raise ValueError('missing MM0B header')
@@ -436,7 +717,6 @@ def verify_mmb(_mm0_path: str, mmb_path: str):
         if ptr > size:
             raise ValueError('pointer out of range')
 
-    # sort table directly follows the header
     if 40 + num_sorts > size:
         raise ValueError('sort table exceeds file size')
 
@@ -453,23 +733,24 @@ def verify_mmb(_mm0_path: str, mmb_path: str):
         check_ptr(p_index, 8)
 
 
-
-def main(argv=None):
+def main(argv: Optional[Sequence[str]] = None) -> None:
     import argparse
-    parser = argparse.ArgumentParser(description="Minimal MMU verifier")
-    parser.add_argument(
-        'files', nargs='+', help='MMU file or MM0 and proof file')
+    import os
+
+    parser = argparse.ArgumentParser(description='Minimal MMU verifier')
+    parser.add_argument('files', nargs='+', help='MMU file or MM0 and proof file')
     parser.add_argument('--log-file', dest='log_file', help='write logs to FILE')
-    parser.add_argument('-v', '--verbose', action='store_true',
-                        help='enable verbose logging')
+    parser.add_argument('-v', '--verbose', action='store_true', help='enable verbose logging')
     args = parser.parse_args(argv)
 
     log_level = logging.DEBUG if args.verbose else logging.INFO
-    logging.basicConfig(level=log_level,
-                        filename=args.log_file,
-                        format='%(message)s')
+    logging.basicConfig(
+        level=log_level,
+        filename=args.log_file,
+        format='%(message)s',
+    )
     logger = logging.getLogger('mmu')
-    import os
+
     if len(args.files) == 1:
         path = args.files[0]
         if path.endswith('.mmu'):
@@ -477,8 +758,8 @@ def main(argv=None):
                 parser.error(f'{path} is a directory, expected a file')
             try:
                 verify_mmu(path, logger=logger)
-            except Exception as e:
-                parser.exit(1, f"error: {e}\n")
+            except Exception as e:  # noqa: BLE001
+                parser.exit(1, f'error: {e}\n')
             print('OK')
             return
         parser.error('expected an .mmu file')
@@ -488,8 +769,8 @@ def main(argv=None):
             parser.error('expected file paths, not directories')
         try:
             verify_mmb(mm0_path, mmb_path)
-        except Exception as e:
-            parser.exit(1, f"error: {e}\n")
+        except Exception as e:  # noqa: BLE001
+            parser.exit(1, f'error: {e}\n')
         print('OK')
         return
     elif len(args.files) == 2:
@@ -498,8 +779,8 @@ def main(argv=None):
             parser.error(f'{mmu_path} is a directory, expected a file')
         try:
             verify_mmu(mmu_path, logger=logger)
-        except Exception as e:
-            parser.exit(1, f"error: {e}\n")
+        except Exception as e:  # noqa: BLE001
+            parser.exit(1, f'error: {e}\n')
         print('OK')
         return
     else:

--- a/tests/mm0_mmu/bad_dummy_in_hyp.mm0
+++ b/tests/mm0_mmu/bad_dummy_in_hyp.mm0
@@ -1,0 +1,5 @@
+delimiter $ ( ) $;
+sort nat;
+provable sort wff;
+term eq (a: nat) (b: nat): wff;
+theorem bad_dummy_hyp (a: nat) (h: $ eq a b $): $ eq a a $;

--- a/tests/mm0_mmu/bad_dummy_in_hyp.mmu
+++ b/tests/mm0_mmu/bad_dummy_in_hyp.mmu
@@ -1,0 +1,4 @@
+(sort nat)
+(sort wff strict provable)
+(term eq ((a nat ()) (b nat ())) (wff ()))
+(pub theorem bad_dummy_hyp ((a nat ())) ((h (eq a b))) (eq a a) ((b nat)) h)

--- a/tests/mm0_mmu/bad_nonprovable_concl.mm0
+++ b/tests/mm0_mmu/bad_nonprovable_concl.mm0
@@ -1,0 +1,3 @@
+delimiter $ ( ) $;
+sort foo;
+theorem bad_nonprovable (x: foo): x;

--- a/tests/mm0_mmu/bad_nonprovable_concl.mmu
+++ b/tests/mm0_mmu/bad_nonprovable_concl.mmu
@@ -1,0 +1,2 @@
+(sort foo)
+(pub theorem bad_nonprovable ((x foo ())) () x () x)

--- a/tests/mm0_mmu/bad_param_shadowing.mm0
+++ b/tests/mm0_mmu/bad_param_shadowing.mm0
@@ -1,0 +1,3 @@
+delimiter $ ( ) $;
+provable sort wff;
+theorem bad_shadow (p: wff) (p: wff): $ p $;

--- a/tests/mm0_mmu/bad_param_shadowing.mmu
+++ b/tests/mm0_mmu/bad_param_shadowing.mmu
@@ -1,0 +1,2 @@
+(sort wff provable)
+(pub theorem bad_shadow ((p wff ()) (p wff ())) () p () p)

--- a/tests/test_mmu_examples.py
+++ b/tests/test_mmu_examples.py
@@ -33,6 +33,9 @@ CASES = [
     ("tests/mm0_mmu/bad_dummy_escape.mmu", True),
     ("tests/mm0_mmu/bad_strict_dep_in_arg.mmu", True),
     ("tests/mm0_mmu/bad_cong_mismatch.mmu", True),
+    ("tests/mm0_mmu/bad_param_shadowing.mmu", True),
+    ("tests/mm0_mmu/bad_nonprovable_concl.mmu", True),
+    ("tests/mm0_mmu/bad_dummy_in_hyp.mmu", True),
 ]
 
 


### PR DESCRIPTION
## Summary
- rebuild mmu.py around typed binders, term signatures, and strict hygiene checks
- relax strictness to mirror mm0-hs while validating new negative scenarios
- add regression tests for parameter shadowing, non-provable conclusions, and dummy misuse

## Testing
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_68c8813719a48328b60c9a8c734001a0